### PR TITLE
Add help subcommand to all commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.github.austinv11</groupId>
       <artifactId>Discord4J</artifactId>
-      <version>2.8.2</version>
+      <version>2.9.1</version>
     </dependency>
     <!-- Allows you to log events from Discord4J -->
     <dependency>

--- a/src/main/java/chat/DiscordEventManager.java
+++ b/src/main/java/chat/DiscordEventManager.java
@@ -27,7 +27,9 @@ import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.api.events.EventSubscriber;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
 import sx.blah.discord.handle.impl.events.ReadyEvent;
+import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IMessage;
+import static util.MessageUtils.sendMessage;
 
 /**
  * This class is used to setup handlers for various events that are broadcast
@@ -58,10 +60,20 @@ public class DiscordEventManager {
 
     if (message.getMentions().indexOf(_dave.getOurUser()) != -1) {
       String commandMessage = message.getContent().split(" ")[1];
+      String commandMessageAddition = "";
+
+      if (message.getContent().split(" ").length >= 3) {
+        commandMessageAddition = message.getContent().split(" ")[2];
+      }
 
       for (Commands command : Commands.values()) {
         if (command.equals(commandMessage)) {
-          command.getHandler().processCommand(_dave, message);
+          if (commandMessageAddition.equals("help")) {
+            sendMessage(_dave, message.getChannel(),
+                command.getHandler().getHelpText());
+          } else {
+             command.getHandler().processCommand(_dave, message);
+          }
         }
       }
     }

--- a/src/main/java/chat/commands/Help.java
+++ b/src/main/java/chat/commands/Help.java
@@ -27,6 +27,7 @@ import chat.Commands;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IMessage;
+import sx.blah.discord.handle.obj.IPrivateChannel;
 import static util.MessageUtils.sendMessage;
 
 /**
@@ -41,18 +42,19 @@ public class Help extends Command {
   @Override
   public void processCommand(IDiscordClient dave, IMessage message) {
     IChannel channel = message.getChannel();
-
     String content = "Dave will respond to a command if you "
-            + "mention him and then type in the command. \n";
+        + "mention him and then type in the command. \n\n"
+        + "Available commands: \n\n";
     
     for (Commands command : Commands.values()) {
-      content += command.getHandler().getHelpText();
+      content += "    " + command.toString() + "\n";
     }
 
-    content += "\nIf you want to request a new feature, or report a bug, "
+    content += "\nType \"@Dave <command> help\" to get detailed information.\n"
+            + "\nIf you want to request a new feature, or report a bug, "
             + "please use the issue tracker on github!\n" +
             "https://github.com/ceruzaa/Dave \n";
-    
+
     sendMessage(dave, channel, content);
   }
 


### PR DESCRIPTION
Related to issue #4 in github, I've created a
small improvement that allows users to use
"@Dave ping help" to get the help info for
the ping command instead of forcing the use
of "@Dave help" to display the help text of
all commands. "@Dave help" now only returns
a list of all commands.